### PR TITLE
Remove stages restrictions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     }
   },
   "require": {
-    "illuminate/database": "~6.0",
-    "mongodb/mongodb": "~1.6",
-    "php": "~7.3"
+    "illuminate/database": ">=6.0",
+    "mongodb/mongodb": ">=1.6",
+    "php": "~7.3|^8.0"
   },
   "autoload-dev": {
    "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     }
   },
   "require": {
-    "illuminate/database": "^6.0",
-    "mongodb/mongodb": "^1.6",
-    "php": "^7.3"
+    "illuminate/database": "~6.0",
+    "mongodb/mongodb": "~1.6",
+    "php": "~7.3"
   },
   "autoload-dev": {
    "classmap": [
@@ -20,8 +20,8 @@
    ]
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0",
-    "orchestra/testbench": "^4.0"
+    "phpunit/phpunit": "~8.0",
+    "orchestra/testbench": "~4.0"
   },
   "scripts": {
     "test": "phpunit tests"

--- a/src/MongoDB/Aggregate/Builder.php
+++ b/src/MongoDB/Aggregate/Builder.php
@@ -76,10 +76,29 @@ class Builder
     }
 
     /**
-     * Concat an array of stages to the end of the existing pipeline
+     * Concat an array of stages to the end of the existing pipeline,
+     * will ignore any stages not supported by the builder
      * @param array $stages
      */
-    public function addStages(Iterable $stages)
+    public function addStages(iterable $stages)
+    {
+        // We don't want to array_merge, we want to go through and add each stage per our builder. We don't know where these came from.
+        foreach ($stages as $stage) {
+            if (!empty($stage)) {
+                $stageName = str_replace('$', '', array_keys($stage)[0]);
+                if (method_exists($this, $stageName)) {
+                    $this->{$stageName}($stage["\${$stageName}"]);
+                }
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Concat an array of stages to the end of the existing pipeline as is
+     * @param array $stages
+     */
+    public function addRawStages(Iterable $stages)
     {
         foreach ($stages as $stage) {
             $this->addStage($stage);
@@ -91,7 +110,7 @@ class Builder
      * @param array $stage - <code>[ $query_array ]</code>
      * @return Builder
      */
-    public function match(Iterable $stage): Builder
+    public function match(iterable $stage): Builder
     {
         $this->pipeline[] = ['$match' => $stage];
         return $this;
@@ -107,7 +126,7 @@ class Builder
      * </code>
      * @return Builder
      */
-    public function group(Iterable $stage): Builder
+    public function group(iterable $stage): Builder
     {
         $this->pipeline[] = ['$group' => $stage];
         return $this;
@@ -117,7 +136,7 @@ class Builder
      * @param array $stage - <code>[ $projection_specifications ]</code>
      * @return Builder
      */
-    public function project(Iterable $stage): Builder
+    public function project(iterable $stage): Builder
     {
         $this->pipeline[] = ['$project' => $stage];
         return $this;
@@ -132,7 +151,7 @@ class Builder
      * </code>
      * @return Builder
      */
-    public function set(Iterable $stage): Builder
+    public function set(iterable $stage): Builder
     {
         $this->pipeline[] = ['$set' => $stage];
         return $this;

--- a/src/MongoDB/Aggregate/Builder.php
+++ b/src/MongoDB/Aggregate/Builder.php
@@ -76,21 +76,15 @@ class Builder
     }
 
     /**
-     * Concat an array of stages to the end of the existing pipeline,
-     * will ignore any stages not supported by the builder
+     * Concat an array of stages to the end of the existing pipeline
      * @param array $stages
      */
     public function addStages(Iterable $stages)
     {
-        // We don't want to array_merge, we want to go through and add each stage per our builder. We don't know where these came from.
         foreach ($stages as $stage) {
-            if (!empty($stage)) {
-                $stageName = str_replace('$', '', array_keys($stage)[0]);
-                if (method_exists($this, $stageName)) {
-                    $this->{$stageName}($stage["\${$stageName}"]);
-                }
-            }
+            $this->addStage($stage);
         }
+        return $this;
     }
 
     /**

--- a/tests/MongoAggregateBuilderTest.php
+++ b/tests/MongoAggregateBuilderTest.php
@@ -116,28 +116,7 @@ class MongoAggregateBuilderTest extends TestCase
             ]
         ];
         $this->builder->addStages($stages);
-        $this->assertEquals(
-            [
-                [
-                    '$match' => [
-                        'organization_id' => 1,
-                        'asset_id' => [
-                            '$in' => [
-                                4,
-                                5,
-                                6,
-                            ],
-                        ],
-                    ]
-                ],
-                [
-                    '$project' => [
-                        '_id' => false,
-                        'asset_id' => true,
-                    ]
-                ]
-            ],
-            $this->builder->getPipeline()
+        $this->assertEquals($stages, $this->builder->getPipeline()
         );
     }
 

--- a/tests/MongoAggregateBuilderTest.php
+++ b/tests/MongoAggregateBuilderTest.php
@@ -115,30 +115,13 @@ class MongoAggregateBuilderTest extends TestCase
                 ]
             ]
         ];
-        $this->builder->addStages($stages);
-        $this->assertEquals(
-            [
-                [
-                    '$match' => [
-                        'organization_id' => 1,
-                        'asset_id' => [
-                            '$in' => [
-                                4,
-                                5,
-                                6,
-                            ],
-                        ],
-                    ]
-                ],
-                [
-                    '$project' => [
-                        '_id' => false,
-                        'asset_id' => true,
-                    ]
-                ]
-            ],
-            $this->builder->getPipeline()
-        );
+        try {
+            $this->builder->addStages($stages);
+        } catch (\MongoDB\Exception\InvalidArgumentException $iae) {
+            $this->assertEquals("\$find is not a supported aggregate stage.", $iae->getMessage());
+        }
+
+        $this->assertEquals([], $this->builder->getPipeline());
     }
 
     public function testCanAddRawStages()
@@ -165,8 +148,7 @@ class MongoAggregateBuilderTest extends TestCase
             ]
         ];
         $this->builder->addRawStages($stages);
-        $this->assertEquals($stages, $this->builder->getPipeline()
-        );
+        $this->assertEquals($stages, $this->builder->getPipeline());
     }
 
     public function testCanSetAndGetOptions()

--- a/tests/MongoAggregateBuilderTest.php
+++ b/tests/MongoAggregateBuilderTest.php
@@ -116,6 +116,55 @@ class MongoAggregateBuilderTest extends TestCase
             ]
         ];
         $this->builder->addStages($stages);
+        $this->assertEquals(
+            [
+                [
+                    '$match' => [
+                        'organization_id' => 1,
+                        'asset_id' => [
+                            '$in' => [
+                                4,
+                                5,
+                                6,
+                            ],
+                        ],
+                    ]
+                ],
+                [
+                    '$project' => [
+                        '_id' => false,
+                        'asset_id' => true,
+                    ]
+                ]
+            ],
+            $this->builder->getPipeline()
+        );
+    }
+
+    public function testCanAddRawStages()
+    {
+        $stages = [
+            [
+                '$match' => [
+                    'organization_id' => 1,
+                    'asset_id' => [
+                        '$in' => [
+                            4,
+                            5,
+                            6,
+                        ],
+                    ],
+                ]
+            ],
+            ['$find' => 'is not a legal aggregate pipeline stage'],
+            [
+                '$project' => [
+                    '_id' => false,
+                    'asset_id' => true,
+                ]
+            ]
+        ];
+        $this->builder->addRawStages($stages);
         $this->assertEquals($stages, $this->builder->getPipeline()
         );
     }


### PR DESCRIPTION
Loosened the composer requirements to allow for newer versions of Laravel.
Added a raw version of `addStages` function, `addRawStages`. They both return $this for chaining.
Invalid or unsupported stage names found while executing `addStages` will now throw a MongoDB `InvalidArgumentException`.